### PR TITLE
Extend URI and file sources to support separate audio and video resource...

### DIFF
--- a/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/FileSource.java
+++ b/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/FileSource.java
@@ -28,9 +28,25 @@ import java.io.IOException;
 public class FileSource implements MediaSource {
 
     private File mFile;
+    private File mAudioFile;
 
+    /**
+     * Creates a media source from a local file. The file can be either video-only, or multiplexed
+     * audio/video.
+     * @param file the av source file
+     */
     public FileSource(File file) {
         mFile = file;
+    }
+
+    /**
+     * Creates a media source from separate local video and audio files.
+     * @param videoFile the video source file
+     * @param audioFile the audio source file
+     */
+    public FileSource(File videoFile, File audioFile) {
+        mFile = videoFile;
+        mAudioFile = audioFile;
     }
 
     @Override
@@ -42,6 +58,14 @@ public class FileSource implements MediaSource {
 
     @Override
     public MediaExtractor getAudioExtractor() throws IOException {
-        return null; // FileSource does only handle single (multiplexed) files
+        if(mAudioFile != null) {
+            // In case of a separate audio file, return an audio extractor
+            MediaExtractor mediaExtractor = new MediaExtractor();
+            mediaExtractor.setDataSource(mAudioFile.getAbsolutePath());
+            return mediaExtractor;
+        }
+        // We do not need a separate audio extractor when only a single (multiplexed) file
+        // is passed into this class.
+        return null;
     }
 }

--- a/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/UriSource.java
+++ b/MediaPlayer/src/main/java/at/aau/itec/android/mediaplayer/UriSource.java
@@ -32,17 +32,60 @@ public class UriSource implements MediaSource {
 
     private Context mContext;
     private Uri mUri;
+    private Uri mAudioUri;
     private Map<String, String> mHeaders;
+    private Map<String, String> mAudioHeaders;
 
+    /**
+     * Creates a media source from a URI. The media source must either be a video stream
+     * or a multiplexed audio/video stream.
+     * @param context the context to open the URI in
+     * @param uri the URI pointing to the media source
+     * @param headers the headers to be passed with the request to the URI
+     */
     public UriSource(Context context, Uri uri, Map<String, String> headers) {
         this.mContext = context;
         this.mUri = uri;
         this.mHeaders = headers;
     }
 
+    /**
+     * Creates a media source from a URI. The media source must either be a video stream
+     * or a multiplexed audio/video stream.
+     * @param context the context to open the URI in
+     * @param uri the URI pointing to the media source
+     */
     public UriSource(Context context, Uri uri) {
         this.mContext = context;
         this.mUri = uri;
+    }
+
+    /**
+     * Creates a media source from separate video and audio URIs.
+     * @param context the context to open the URIs in
+     * @param videoUri the URI pointing to the video source
+     * @param videoHeaders the headers to be passed with the request to the video URI
+     * @param audioUri the URI pointing to the audio source
+     * @param audioHeaders the headers to be passed with the request to the audio URI
+     */
+    public UriSource(Context context, Uri videoUri, Map<String, String> videoHeaders, Uri audioUri, Map<String, String> audioHeaders) {
+        this.mContext = context;
+        this.mUri = videoUri;
+        this.mHeaders = videoHeaders;
+        this.mAudioUri = audioUri;
+        this.mAudioHeaders = audioHeaders;
+    }
+
+    /**
+     * Creates a media source from separate video and audio URIs.
+     * @param context the context to open the URIs in
+     * @param videoUri the URI pointing to the video source
+     * @param audioUri the URI pointing to the audio source
+     */
+    public UriSource(Context context, Uri videoUri, Uri audioUri) {
+        this.mContext = context;
+        this.mUri = videoUri;
+        this.mAudioUri = audioUri;
     }
 
     public Context getContext() {
@@ -66,6 +109,14 @@ public class UriSource implements MediaSource {
 
     @Override
     public MediaExtractor getAudioExtractor() throws IOException {
-        return null; // UriSource does only handle single (multiplexed) files
+        if(mAudioUri != null) {
+            // In case of a separate audio file Uri, return an audio extractor
+            MediaExtractor mediaExtractor = new MediaExtractor();
+            mediaExtractor.setDataSource(mContext, mAudioUri, mAudioHeaders);
+            return mediaExtractor;
+        }
+        // We do not need a separate audio extractor when only a single Uri to a single
+        // (multiplexed) file is passed into this class.
+        return null;
     }
 }


### PR DESCRIPTION
...s

Before, only a single URI of file could be passed that either had to be a video source or a multiplexed audio/video source. Now, a separate URI or file can be specified for an external audio source.
